### PR TITLE
Fix module path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module feedback-api
+module github.com/LeastAuthority/feedback-api
 
 go 1.19
 


### PR DESCRIPTION
Fix module path, as it is not possible install it:

```
go install github.com/LeastAuthority/feedback-api@latest
go: downloading github.com/LeastAuthority/feedback-api v0.0.0-20230120210314-96b0613fec8e
go: github.com/LeastAuthority/feedback-api@latest: github.com/LeastAuthority/feedback-api@v0.0.0-20230120210314-96b0613fec8e: parsing go.mod:
	module declares its path as: feedback-api
	        but was required as: github.com/LeastAuthority/feedback-api
```